### PR TITLE
Support central conf package for ETL app.

### DIFF
--- a/.etl.env
+++ b/.etl.env
@@ -1,0 +1,27 @@
+ETL_CLICK_API=https://clickrevaha-sys.molsa.gov.il/api/solr?rows=1000
+
+ETL_GUIDESTAR_USERNAME=
+ETL_GUIDESTAR_PASSWORD=
+ETL_GUIDESTAR_API=https://www.guidestar.org.il/services/apexrest/api
+
+ETL_GOVMAP_API_KEY=
+ETL_GOVMAP_AUTH=https://ags.govmap.gov.il/Api/Controllers/GovmapApi/Auth
+ETL_GOVMAP_REQUEST_ORIGIN=https://www.kolzchut.org.il
+ETL_GOVMAP_GEOCODE_API=https://ags.govmap.gov.il/Api/Controllers/GovmapApi/Geocode
+
+ETL_AIRTABLE_BASE=appF3FyNsyk4zObNa
+ETL_AIRTABLE_VIEW='Grid view'
+ETL_AIRTABLE_LOCATION_TABLE=Locations
+ETL_AIRTABLE_ORGANIZATION_TABLE=Organizations
+ETL_AIRTABLE_BRANCH_TABLE=Branches
+ETL_AIRTABLE_SITUATION_TABLE=Situations
+
+ETL_MAPBOX_ACCESS_TOKEN=
+ETL_MAPBOX_LIST_TILESETS=https://api.mapbox.com/tilesets/v1/srm-kolzchut
+ETL_MAPBOX_UPLOAD_CREDENTIALS=https://api.mapbox.com/uploads/v1/srm-kolzchut/credentials
+ETL_MAPBOX_CREATE_UPLOAD=https://api.mapbox.com/uploads/v1/srm-kolzchut
+ETL_MAPBOX_UPLOAD_STATUS=https://api.mapbox.com/uploads/v1/srm-kolzchut/
+
+ETL_DATAFLOWS_AIRTABLE_APIKEY=
+
+GOOGLE_API_KEY=

--- a/.etl.env
+++ b/.etl.env
@@ -22,6 +22,6 @@ ETL_MAPBOX_UPLOAD_CREDENTIALS=https://api.mapbox.com/uploads/v1/srm-kolzchut/cre
 ETL_MAPBOX_CREATE_UPLOAD=https://api.mapbox.com/uploads/v1/srm-kolzchut
 ETL_MAPBOX_UPLOAD_STATUS=https://api.mapbox.com/uploads/v1/srm-kolzchut/
 
-ETL_DATAFLOWS_AIRTABLE_APIKEY=
-
 ETL_GOOGLE_MAPS_API_KEY=
+
+DATAFLOWS_AIRTABLE_APIKEY=

--- a/.etl.env
+++ b/.etl.env
@@ -24,4 +24,4 @@ ETL_MAPBOX_UPLOAD_STATUS=https://api.mapbox.com/uploads/v1/srm-kolzchut/
 
 ETL_DATAFLOWS_AIRTABLE_APIKEY=
 
-GOOGLE_API_KEY=
+ETL_GOOGLE_MAPS_API_KEY=

--- a/.etl.env
+++ b/.etl.env
@@ -1,27 +1,12 @@
-ETL_CLICK_API=https://clickrevaha-sys.molsa.gov.il/api/solr?rows=1000
-
 ETL_GUIDESTAR_USERNAME=
 ETL_GUIDESTAR_PASSWORD=
-ETL_GUIDESTAR_API=https://www.guidestar.org.il/services/apexrest/api
 
 ETL_GOVMAP_API_KEY=
-ETL_GOVMAP_AUTH=https://ags.govmap.gov.il/Api/Controllers/GovmapApi/Auth
-ETL_GOVMAP_REQUEST_ORIGIN=https://www.kolzchut.org.il
-ETL_GOVMAP_GEOCODE_API=https://ags.govmap.gov.il/Api/Controllers/GovmapApi/Geocode
 
 ETL_AIRTABLE_BASE=appF3FyNsyk4zObNa
-ETL_AIRTABLE_VIEW='Grid view'
-ETL_AIRTABLE_LOCATION_TABLE=Locations
-ETL_AIRTABLE_ORGANIZATION_TABLE=Organizations
-ETL_AIRTABLE_BRANCH_TABLE=Branches
-ETL_AIRTABLE_SITUATION_TABLE=Situations
-
-ETL_MAPBOX_ACCESS_TOKEN=
-ETL_MAPBOX_LIST_TILESETS=https://api.mapbox.com/tilesets/v1/srm-kolzchut
-ETL_MAPBOX_UPLOAD_CREDENTIALS=https://api.mapbox.com/uploads/v1/srm-kolzchut/credentials
-ETL_MAPBOX_CREATE_UPLOAD=https://api.mapbox.com/uploads/v1/srm-kolzchut
-ETL_MAPBOX_UPLOAD_STATUS=https://api.mapbox.com/uploads/v1/srm-kolzchut/
 
 ETL_GOOGLE_MAPS_API_KEY=
+
+ETL_MAPBOX_ACCESS_TOKEN=
 
 DATAFLOWS_AIRTABLE_APIKEY=

--- a/README.md
+++ b/README.md
@@ -86,6 +86,12 @@ Create .env file
 bin/generate_key_pair.sh > .env
 ```
 
+Add environment variables for the ETL server (empty secrets will need to be updated with real values):
+
+```
+cat .etl.env >> .env
+```
+
 Generate Google OAuth credentials - https://console.developers.google.com/apis/credentials
 
 ```

--- a/helm/etl/templates/etl-deployment.yaml
+++ b/helm/etl/templates/etl-deployment.yaml
@@ -68,41 +68,13 @@ spec:
               value: "postgresql://postgres:postgres@{{ .Values.db.name }}/etls"
             - name: ETL_GOOGLE_MAPS_API_KEY
               valueFrom: {"secretKeyRef":{"name":{{ .Values.etl.secretName | quote }}, "key":"ETL_GOOGLE_MAPS_API_KEY"}}
-            - name: ETL_CLICK_API
-              valueFrom: {"secretKeyRef":{"name":{{ .Values.etl.secretName | quote }}, "key":"ETL_CLICK_API"}}
             - name: ETL_GUIDESTAR_USERNAME
               valueFrom: {"secretKeyRef":{"name":{{ .Values.etl.secretName | quote }}, "key":"ETL_GUIDESTAR_USERNAME"}}
             - name: ETL_GUIDESTAR_PASSWORD
               valueFrom: {"secretKeyRef":{"name":{{ .Values.etl.secretName | quote }}, "key":"ETL_GUIDESTAR_PASSWORD"}}
-            - name: ETL_GUIDESTAR_API
-              valueFrom: {"secretKeyRef":{"name":{{ .Values.etl.secretName | quote }}, "key":"ETL_GUIDESTAR_API"}}
             - name: ETL_GOVMAP_API_KEY
               valueFrom: {"secretKeyRef":{"name":{{ .Values.etl.secretName | quote }}, "key":"ETL_GOVMAP_API_KEY"}}
-            - name: ETL_GOVMAP_AUTH
-              valueFrom: {"secretKeyRef":{"name":{{ .Values.etl.secretName | quote }}, "key":"ETL_GOVMAP_AUTH"}}
-            - name: ETL_GOVMAP_REQUEST_ORIGIN
-              valueFrom: {"secretKeyRef":{"name":{{ .Values.etl.secretName | quote }}, "key":"ETL_GOVMAP_REQUEST_ORIGIN"}}
-            - name: ETL_GOVMAP_GEOCODE_API
-              valueFrom: {"secretKeyRef":{"name":{{ .Values.etl.secretName | quote }}, "key":"ETL_GOVMAP_GEOCODE_API"}}
             - name: ETL_AIRTABLE_BASE
               valueFrom: {"secretKeyRef":{"name":{{ .Values.etl.secretName | quote }}, "key":"ETL_AIRTABLE_BASE"}}
-            - name: ETL_AIRTABLE_VIEW
-              valueFrom: {"secretKeyRef":{"name":{{ .Values.etl.secretName | quote }}, "key":"ETL_AIRTABLE_VIEW"}}
-            - name: ETL_AIRTABLE_LOCATION_TABLE
-              valueFrom: {"secretKeyRef":{"name":{{ .Values.etl.secretName | quote }}, "key":"ETL_AIRTABLE_LOCATION_TABLE"}}
-            - name: ETL_AIRTABLE_ORGANIZATION_TABLE
-              valueFrom: {"secretKeyRef":{"name":{{ .Values.etl.secretName | quote }}, "key":"ETL_AIRTABLE_ORGANIZATION_TABLE"}}
-            - name: ETL_AIRTABLE_BRANCH_TABLE
-              valueFrom: {"secretKeyRef":{"name":{{ .Values.etl.secretName | quote }}, "key":"ETL_AIRTABLE_BRANCH_TABLE"}}
-            - name: ETL_AIRTABLE_SITUATION_TABLE
-              valueFrom: {"secretKeyRef":{"name":{{ .Values.etl.secretName | quote }}, "key":"ETL_AIRTABLE_SITUATION_TABLE"}}
             - name: ETL_MAPBOX_ACCESS_TOKEN
               valueFrom: {"secretKeyRef":{"name":{{ .Values.etl.secretName | quote }}, "key":"ETL_MAPBOX_ACCESS_TOKEN"}}
-            - name: ETL_MAPBOX_LIST_TILESETS
-              valueFrom: {"secretKeyRef":{"name":{{ .Values.etl.secretName | quote }}, "key":"ETL_MAPBOX_LIST_TILESETS"}}
-            - name: ETL_MAPBOX_UPLOAD_CREDENTIALS
-              valueFrom: {"secretKeyRef":{"name":{{ .Values.etl.secretName | quote }}, "key":"ETL_MAPBOX_UPLOAD_CREDENTIALS"}}
-            - name: ETL_MAPBOX_CREATE_UPLOAD
-              valueFrom: {"secretKeyRef":{"name":{{ .Values.etl.secretName | quote }}, "key":"ETL_MAPBOX_CREATE_UPLOAD"}}
-            - name: ETL_MAPBOX_UPLOAD_STATUS
-              valueFrom: {"secretKeyRef":{"name":{{ .Values.etl.secretName | quote }}, "key":"ETL_MAPBOX_UPLOAD_STATUS"}}

--- a/helm/etl/templates/etl-deployment.yaml
+++ b/helm/etl/templates/etl-deployment.yaml
@@ -62,12 +62,12 @@ spec:
               value: "postgresql://postgres:postgres@{{ .Values.db.name }}/datasets"
             - name: AIRFLOW__CORE__SQL_ALCHEMY_CONN
               value: "postgresql://postgres:postgres@{{ .Values.db.name }}/airflow"
+            - name: DATAFLOWS_AIRTABLE_APIKEY
+              valueFrom: {"secretKeyRef":{"name":{{ .Values.etl.secretName | quote }}, "key":"DATAFLOWS_AIRTABLE_APIKEY"}}
             - name: ETLS_DATABASE_URL
               value: "postgresql://postgres:postgres@{{ .Values.db.name }}/etls"
             - name: ETL_GOOGLE_MAPS_API_KEY
               valueFrom: {"secretKeyRef":{"name":{{ .Values.etl.secretName | quote }}, "key":"ETL_GOOGLE_MAPS_API_KEY"}}
-            - name: ETL_DATAFLOWS_AIRTABLE_APIKEY
-              valueFrom: {"secretKeyRef":{"name":{{ .Values.etl.secretName | quote }}, "key":"ETL_DATAFLOWS_AIRTABLE_APIKEY"}}
             - name: ETL_CLICK_API
               valueFrom: {"secretKeyRef":{"name":{{ .Values.etl.secretName | quote }}, "key":"ETL_CLICK_API"}}
             - name: ETL_GUIDESTAR_USERNAME

--- a/helm/etl/templates/etl-deployment.yaml
+++ b/helm/etl/templates/etl-deployment.yaml
@@ -64,15 +64,45 @@ spec:
               value: "postgresql://postgres:postgres@{{ .Values.db.name }}/airflow"
             - name: ETLS_DATABASE_URL
               value: "postgresql://postgres:postgres@{{ .Values.db.name }}/etls"
-            - name: GUIDESTAR_PASSWORD
-              valueFrom: {"secretKeyRef":{"name":{{ .Values.etl.secretName | quote }}, "key":"GUIDESTAR_PASSWORD"}}
-            - name: GUIDESTAR_USERNAME
-              valueFrom: {"secretKeyRef":{"name":{{ .Values.etl.secretName | quote }}, "key":"GUIDESTAR_USERNAME"}}
-            - name: DATAFLOWS_AIRTABLE_APIKEY
-              valueFrom: {"secretKeyRef":{"name":{{ .Values.etl.secretName | quote }}, "key":"DATAFLOWS_AIRTABLE_APIKEY"}}
             - name: GOOGLE_API_KEY
               valueFrom: {"secretKeyRef":{"name":{{ .Values.etl.secretName | quote }}, "key":"GOOGLE_API_KEY"}}
-            - name: GOVMAP_API_KEY
-              valueFrom: {"secretKeyRef":{"name":{{ .Values.etl.secretName | quote }}, "key":"GOVMAP_API_KEY"}}
-            - name: MAPBOX_ACCESS_TOKEN
-              valueFrom: {"secretKeyRef":{"name":{{ .Values.etl.secretName | quote }}, "key":"MAPBOX_ACCESS_TOKEN"}}
+            - name: ETL_DATAFLOWS_AIRTABLE_APIKEY
+              valueFrom: {"secretKeyRef":{"name":{{ .Values.etl.secretName | quote }}, "key":"ETL_DATAFLOWS_AIRTABLE_APIKEY"}}
+            - name: ETL_CLICK_API
+              valueFrom: {"secretKeyRef":{"name":{{ .Values.etl.secretName | quote }}, "key":"ETL_CLICK_API"}}
+            - name: ETL_GUIDESTAR_USERNAME
+              valueFrom: {"secretKeyRef":{"name":{{ .Values.etl.secretName | quote }}, "key":"ETL_GUIDESTAR_USERNAME"}}
+            - name: ETL_GUIDESTAR_PASSWORD
+              valueFrom: {"secretKeyRef":{"name":{{ .Values.etl.secretName | quote }}, "key":"ETL_GUIDESTAR_PASSWORD"}}
+            - name: ETL_GUIDESTAR_API
+              valueFrom: {"secretKeyRef":{"name":{{ .Values.etl.secretName | quote }}, "key":"ETL_GUIDESTAR_API"}}
+            - name: ETL_GOVMAP_API_KEY
+              valueFrom: {"secretKeyRef":{"name":{{ .Values.etl.secretName | quote }}, "key":"ETL_GOVMAP_API_KEY"}}
+            - name: ETL_GOVMAP_AUTH
+              valueFrom: {"secretKeyRef":{"name":{{ .Values.etl.secretName | quote }}, "key":"ETL_GOVMAP_AUTH"}}
+            - name: ETL_GOVMAP_REQUEST_ORIGIN
+              valueFrom: {"secretKeyRef":{"name":{{ .Values.etl.secretName | quote }}, "key":"ETL_GOVMAP_REQUEST_ORIGIN"}}
+            - name: ETL_GOVMAP_GEOCODE_API
+              valueFrom: {"secretKeyRef":{"name":{{ .Values.etl.secretName | quote }}, "key":"ETL_GOVMAP_GEOCODE_API"}}
+            - name: ETL_AIRTABLE_BASE
+              valueFrom: {"secretKeyRef":{"name":{{ .Values.etl.secretName | quote }}, "key":"ETL_AIRTABLE_BASE"}}
+            - name: ETL_AIRTABLE_VIEW
+              valueFrom: {"secretKeyRef":{"name":{{ .Values.etl.secretName | quote }}, "key":"ETL_AIRTABLE_VIEW"}}
+            - name: ETL_AIRTABLE_LOCATION_TABLE
+              valueFrom: {"secretKeyRef":{"name":{{ .Values.etl.secretName | quote }}, "key":"ETL_AIRTABLE_LOCATION_TABLE"}}
+            - name: ETL_AIRTABLE_ORGANIZATION_TABLE
+              valueFrom: {"secretKeyRef":{"name":{{ .Values.etl.secretName | quote }}, "key":"ETL_AIRTABLE_ORGANIZATION_TABLE"}}
+            - name: ETL_AIRTABLE_BRANCH_TABLE
+              valueFrom: {"secretKeyRef":{"name":{{ .Values.etl.secretName | quote }}, "key":"ETL_AIRTABLE_BRANCH_TABLE"}}
+            - name: ETL_AIRTABLE_SITUATION_TABLE
+              valueFrom: {"secretKeyRef":{"name":{{ .Values.etl.secretName | quote }}, "key":"ETL_AIRTABLE_SITUATION_TABLE"}}
+            - name: ETL_MAPBOX_ACCESS_TOKEN
+              valueFrom: {"secretKeyRef":{"name":{{ .Values.etl.secretName | quote }}, "key":"ETL_MAPBOX_ACCESS_TOKEN"}}
+            - name: ETL_MAPBOX_LIST_TILESETS
+              valueFrom: {"secretKeyRef":{"name":{{ .Values.etl.secretName | quote }}, "key":"ETL_MAPBOX_LIST_TILESETS"}}
+            - name: ETL_MAPBOX_UPLOAD_CREDENTIALS
+              valueFrom: {"secretKeyRef":{"name":{{ .Values.etl.secretName | quote }}, "key":"ETL_MAPBOX_UPLOAD_CREDENTIALS"}}
+            - name: ETL_MAPBOX_CREATE_UPLOAD
+              valueFrom: {"secretKeyRef":{"name":{{ .Values.etl.secretName | quote }}, "key":"ETL_MAPBOX_CREATE_UPLOAD"}}
+            - name: ETL_MAPBOX_UPLOAD_STATUS
+              valueFrom: {"secretKeyRef":{"name":{{ .Values.etl.secretName | quote }}, "key":"ETL_MAPBOX_UPLOAD_STATUS"}}

--- a/helm/etl/templates/etl-deployment.yaml
+++ b/helm/etl/templates/etl-deployment.yaml
@@ -64,8 +64,8 @@ spec:
               value: "postgresql://postgres:postgres@{{ .Values.db.name }}/airflow"
             - name: ETLS_DATABASE_URL
               value: "postgresql://postgres:postgres@{{ .Values.db.name }}/etls"
-            - name: GOOGLE_API_KEY
-              valueFrom: {"secretKeyRef":{"name":{{ .Values.etl.secretName | quote }}, "key":"GOOGLE_API_KEY"}}
+            - name: ETL_GOOGLE_MAPS_API_KEY
+              valueFrom: {"secretKeyRef":{"name":{{ .Values.etl.secretName | quote }}, "key":"ETL_GOOGLE_MAPS_API_KEY"}}
             - name: ETL_DATAFLOWS_AIRTABLE_APIKEY
               valueFrom: {"secretKeyRef":{"name":{{ .Values.etl.secretName | quote }}, "key":"ETL_DATAFLOWS_AIRTABLE_APIKEY"}}
             - name: ETL_CLICK_API


### PR DESCRIPTION
Relates to https://github.com/whiletrue-industries/srm-etl/pull/4

Open questions:

1. The Helm config for the ETL service currently refers to both `GOOGLE_KEY` and `GOOGLE_API_KEY`. The Docker Compose section of README only refers to `GOOGLE_KEY` and `GOOGLE_SECRET`. I'm not sure if `GOOGLE_KEY` and `GOOGLE_API_KEY` are the same thing, or different.
2. I don't know where environment variables are actually set for deployment. The docs refer to an optional `.env` file that is kept out of versioning, but I assume that is for deploying from a developer machine and not CI.